### PR TITLE
Major improvements to `RegFile`

### DIFF
--- a/riscy/Makefile
+++ b/riscy/Makefile
@@ -1,6 +1,6 @@
 
 TOP = ..
-SBT ?= java -Xmx2G -Xss8M -jar $(TOP)/sbt-launch.jar
+SBT ?= java -Xmx2G -Xss8M -XX:MaxPermSize=256M -jar $(TOP)/sbt-launch.jar
 
 # Set the MODULE_GEN environment variable to the name of the module generator class
 test :


### PR DESCRIPTION
`RegFile` can have registers of any type. For example, registers can contain bundles. This means less bit twiddling and cleaner abstraction for us, without any hardware or performance overhead!
